### PR TITLE
Add option to define highlight rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-1.0.0 Initial release
+- 1.1.0 [Add option to define highlight rules](https://github.com/tklepzig/vim-buffer-navigator/pull/3)
+- 1.0.0 Initial release

--- a/doc/buffer-navigator.txt
+++ b/doc/buffer-navigator.txt
@@ -92,6 +92,21 @@ let g:BufferNavigatorMapKeys                         *g:BufferNavigatorMapKeys*
 let g:BufferNavigatorWidth                             *g:BufferNavigatorWidth*
     Set the width of the buffer navigator window when not zoomed. Default: 40
 
+let g:BufferNavigatorHighlightRules           *g:BufferNavigatorHighlightRules*
+    Define rules how to highlight nodes defined by a regular expression.
+
+    A rule is defined by the following tuple:
+    ["ruleNameInCamelCase", "regexp", "ctermbg", "ctermfg", "guibg", "guifg"]
+
+    The variable g:BufferNavigatorHighlightRules accepts a list of these rules. Default: []
+
+    Example:
+
+    let g:BufferNavigatorHighlightRules = [
+        "\["rubySpecFile", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
+        "\["markdownFile", ".*\.md", "NONE", "yellow", "NONE", "yellow"],
+        "\]
+
 -------------------------------------------------------------------------------
 Highlight Groups                            *buffer-navigator-highlight-groups*
 

--- a/doc/buffer-navigator.txt
+++ b/doc/buffer-navigator.txt
@@ -122,7 +122,8 @@ highlight BufferNavigatorDir                               *BufferNavigatorDir*
 ===============================================================================
 Changelog                                          *buffer-navigator-changelog*
 
-1.0.0 Initial release
+- 1.1.0 Add option to define highlight rules
+- 1.0.0 Initial release
 
 ===============================================================================
 License                                              *buffer-navigator-license*

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -1,8 +1,8 @@
 let s:bufferLineMapping = {}
 let s:optionWindowWidth = ['BufferNavigatorWidth', 40]
+let s:optionHighlightRules = ['BufferNavigatorHighlightRules', []]
 let s:optionMapKeys = ['BufferNavigatorMapKeys', 1]
 let s:buffername = "buffer-navigator"
-let s:specialMarker = "\x08"
 let s:fileMarker = "\x07"
 let s:modifiedMarker = "\x06"
 let s:previousWinId = -1
@@ -20,7 +20,7 @@ function! s:AddBufferToTree(buffer, tree)
 
   if len(pathSegments) == 1
     return a:tree + [
-          \{ "name": (a:buffer.modified ? s:modifiedMarker : "") . (stridx(pathSegments[0], "_spec") != -1 ? s:specialMarker : "") . pathSegments[0],
+          \{ "name": (a:buffer.modified ? s:modifiedMarker : "") . pathSegments[0],
           \  "bufferNumber": a:buffer.nr,
           \  "children": [] }
           \]
@@ -264,3 +264,17 @@ command! BufferNavigatorToggle :call <SID>Toggle()
 if get(g:, s:optionMapKeys[0], s:optionMapKeys[1])
   nnoremap <silent> <leader>b :BufferNavigatorToggle<cr>
 endif
+
+" For doc:
+"let g:BufferNavigatorHighlightRules = [
+      "\["nameInCamelCase", "regexp", "ctermbg", "ctermfg", "guibg", "guifg"],
+      "\["rubySpecFile", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
+      "\["markDownFile", ".*\.md", "NONE", "yellow", "NONE", "yellow"],
+      "\]
+
+for rule in get(g:,s:optionHighlightRules[0], s:optionHighlightRules[1])
+  let [name, regexp, ctermbg, ctermfg, guibg, guifg] = rule
+  exec 'autocmd filetype buffernavigator syntax match ' . name . ' "\v^\s*' . regexp . '$"'
+  exec 'autocmd filetype buffernavigator highlight ' . name . ' ctermbg='. ctermbg . ' ctermfg=' . ctermfg . ' guibg=' . guibg . ' guifg=' . guifg
+endfor
+

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -2,6 +2,7 @@ let s:bufferLineMapping = {}
 let s:optionWindowWidth = ['BufferNavigatorWidth', 40]
 let s:optionMapKeys = ['BufferNavigatorMapKeys', 1]
 let s:buffername = "buffer-navigator"
+let s:specialMarker = "\x08"
 let s:fileMarker = "\x07"
 let s:modifiedMarker = "\x06"
 let s:previousWinId = -1
@@ -19,7 +20,7 @@ function! s:AddBufferToTree(buffer, tree)
 
   if len(pathSegments) == 1
     return a:tree + [
-          \{ "name": (a:buffer.modified ? s:modifiedMarker : "") . pathSegments[0],
+          \{ "name": (a:buffer.modified ? s:modifiedMarker : "") . (stridx(pathSegments[0], "_spec") != -1 ? s:specialMarker : "") . pathSegments[0],
           \  "bufferNumber": a:buffer.nr,
           \  "children": [] }
           \]

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -265,13 +265,6 @@ if get(g:, s:optionMapKeys[0], s:optionMapKeys[1])
   nnoremap <silent> <leader>b :BufferNavigatorToggle<cr>
 endif
 
-" For doc:
-"let g:BufferNavigatorHighlightRules = [
-      "\["nameInCamelCase", "regexp", "ctermbg", "ctermfg", "guibg", "guifg"],
-      "\["rubySpecFile", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
-      "\["markDownFile", ".*\.md", "NONE", "yellow", "NONE", "yellow"],
-      "\]
-
 for rule in get(g:,s:optionHighlightRules[0], s:optionHighlightRules[1])
   let [name, regexp, ctermbg, ctermfg, guibg, guifg] = rule
   exec 'autocmd filetype buffernavigator syntax match ' . name . ' "\v^\s*' . regexp . '$"'

--- a/syntax/buffernavigator.vim
+++ b/syntax/buffernavigator.vim
@@ -1,9 +1,11 @@
+let s:specialMarker = "\x08"
 let s:fileMarker = "\x07"
 let s:modifiedMarker = "\x06"
 
 " hide the file marker
 exec 'syntax match BufferNavigatorFileMarker #\%d' . char2nr(s:fileMarker) . '# conceal containedin=ALL'
 exec 'syntax match BufferNavigatorModifiedMarker #\%d' . char2nr(s:modifiedMarker) . '# conceal containedin=ALL'
+exec 'syntax match BufferNavigatorSpecialMarker #\%d' . char2nr(s:specialMarker) . '# conceal containedin=ALL'
 
 " all lines are directories
 exec 'syntax match BufferNavigatorDir "\v^.*$"'
@@ -14,6 +16,10 @@ exec 'syntax match BufferNavigatorFile #^\s*\%d' . char2nr(s:fileMarker) . '.*$#
 " highlight modified files
 exec 'syntax match BufferNavigatorModifiedFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:modifiedMarker) . '.*$#'
 
-highlight BufferNavigatorFile ctermbg=NONE ctermfg=Blue guibg=NONE guifg=Blue
+" highlight special files
+exec 'syntax match BufferNavigatorSpecialFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:specialMarker) . '.*$#'
+
+highlight BufferNavigatorSpecialFile ctermbg=NONE ctermfg=154 guibg=NONE guifg=Green
+highlight BufferNavigatorFile ctermbg=NONE ctermfg=75 guibg=NONE guifg=Blue
 highlight BufferNavigatorModifiedFile ctermbg=NONE ctermfg=214 guibg=NONE guifg=Orange
 highlight BufferNavigatorDir ctermbg=NONE ctermfg=White guibg=NONE guifg=White

--- a/syntax/buffernavigator.vim
+++ b/syntax/buffernavigator.vim
@@ -1,11 +1,9 @@
-let s:specialMarker = "\x08"
 let s:fileMarker = "\x07"
 let s:modifiedMarker = "\x06"
 
 " hide the file marker
 exec 'syntax match BufferNavigatorFileMarker #\%d' . char2nr(s:fileMarker) . '# conceal containedin=ALL'
 exec 'syntax match BufferNavigatorModifiedMarker #\%d' . char2nr(s:modifiedMarker) . '# conceal containedin=ALL'
-exec 'syntax match BufferNavigatorSpecialMarker #\%d' . char2nr(s:specialMarker) . '# conceal containedin=ALL'
 
 " all lines are directories
 exec 'syntax match BufferNavigatorDir "\v^.*$"'
@@ -14,12 +12,8 @@ exec 'syntax match BufferNavigatorDir "\v^.*$"'
 exec 'syntax match BufferNavigatorFile #^\s*\%d' . char2nr(s:fileMarker) . '.*$#'
 
 " highlight modified files
-exec 'syntax match BufferNavigatorModifiedFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:modifiedMarker) . '.*$#'
+exec 'syntax match BufferNavigatorModifiedFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:modifiedMarker) . '.*$# containedin=ALL'
 
-" highlight special files
-exec 'syntax match BufferNavigatorSpecialFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:specialMarker) . '.*$#'
-
-highlight BufferNavigatorSpecialFile ctermbg=NONE ctermfg=154 guibg=NONE guifg=Green
 highlight BufferNavigatorFile ctermbg=NONE ctermfg=75 guibg=NONE guifg=Blue
 highlight BufferNavigatorModifiedFile ctermbg=NONE ctermfg=214 guibg=NONE guifg=Orange
 highlight BufferNavigatorDir ctermbg=NONE ctermfg=White guibg=NONE guifg=White


### PR DESCRIPTION
Define rules how to highlight nodes defined by a regular expression.

A rule is defined by the following tuple:
`["ruleNameInCamelCase", "regexp", "ctermbg", "ctermfg", "guibg", "guifg"]`

The variable `g:BufferNavigatorHighlightRules` accepts a list of these rules. Default: `[]`

Example:

```
let g:BufferNavigatorHighlightRules = [
    "\["rubySpecFile", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
    "\["markdownFile", ".*\.md", "NONE", "yellow", "NONE", "yellow"],
    "\]
```
