### PR TITLE
Add MRU mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
-- 1.1.0 [Add option to define highlight rules](https://github.com/tklepzig/vim-buffer-navigator/pull/3)
-- 1.0.0 Initial release
+- 2.0.0
+  - [Add MRU mode](https://github.com/tklepzig/vim-buffer-navigator/pull/4)
+  - BREAKING CHANGE: user-defined highlight rules got a new second parameter:
+    kind ("file" | "dir")
+    see :h g:BufferNavigatorHighlightRules
+- 1.1.0
+  - [Add option to define highlight rules](https://github.com/tklepzig/vim-buffer-navigator/pull/3)
+- 1.0.0
+  - Initial release

--- a/doc/buffer-navigator.txt
+++ b/doc/buffer-navigator.txt
@@ -122,7 +122,7 @@ let g:BufferNavigatorHighlightRules           *g:BufferNavigatorHighlightRules*
 -------------------------------------------------------------------------------
 Highlight Groups                            *buffer-navigator-highlight-groups*
 
-highlight BufferNavigatorFile                      *BufferNavigatorFile* 
+highlight BufferNavigatorFile                             *BufferNavigatorFile* 
     Use this highlight group to define how files are displayed.
  
 highlight BufferNavigatorModifiedFile             *BufferNavigatorModifiedFile*
@@ -138,6 +138,7 @@ Changelog                                          *buffer-navigator-changelog*
   - Add MRU mode
   - BREAKING CHANGE: user-defined highlight rules got a new second parameter:
     kind ("file" | "dir")
+    see :h g:BufferNavigatorHighlightRules
 - 1.1.0
   - Add option to define highlight rules
 - 1.0.0
@@ -148,7 +149,7 @@ License                                              *buffer-navigator-license*
 
 MIT License
 
-Copyright (c) 2021 Thomas Klepzig
+Copyright (c) 2022 Thomas Klepzig
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/buffer-navigator.txt
+++ b/doc/buffer-navigator.txt
@@ -40,6 +40,9 @@ Usage                                                  *buffer-navigator-usage*
 The Buffer Navigator allows you to see your open buffers visualized as
 tree. Additionally, you can switch to any buffer or close one or multiple ones.
 
+When switching to the MRU (Most Recently Used) mode, the open buffers are
+visualized flat, sorted by the last usage.
+
 -------------------------------------------------------------------------------
 Commands                                            *buffer-navigator-commands*
 
@@ -68,8 +71,9 @@ s............Open selected buffer in split
 v............Open selected buffer in vertical split
 p............Open buffer in preview mode (buffer navigator window stays open)
 x............Close selected buffer or tree
-z............Toggle zoom (increase width of buffer navigator window to max width)
+z............Toggle zoom (increase buffer navigator width to maximum)
 r............Refresh buffer tree
+m............Switch between tree and MRU mode
 
 -------------------------------------------------------------------------------
 Global Mappings                              *buffer-navigator-global-mappings*
@@ -92,19 +96,27 @@ let g:BufferNavigatorMapKeys                         *g:BufferNavigatorMapKeys*
 let g:BufferNavigatorWidth                             *g:BufferNavigatorWidth*
     Set the width of the buffer navigator window when not zoomed. Default: 40
 
+let g:BufferNavigatorMode                               *g:BufferNavigatorMode*
+    Set the mode on startup. Default: "tree"
+
 let g:BufferNavigatorHighlightRules           *g:BufferNavigatorHighlightRules*
     Define rules how to highlight nodes defined by a regular expression.
 
     A rule is defined by the following tuple:
-    ["ruleNameInCamelCase", "regexp", "ctermbg", "ctermfg", "guibg", "guifg"]
+    ["ruleName", kind, "regexp", "ctermbg", "ctermfg", "guibg", "guifg"]
+    Where kind can be one of the following values:
+      - "file"
+      - "dir"
 
-    The variable g:BufferNavigatorHighlightRules accepts a list of these rules. Default: []
+    The variable g:BufferNavigatorHighlightRules accepts a list
+    of these rules. Default: []
 
     Example:
 
     let g:BufferNavigatorHighlightRules = [
-        \["rubySpecFile", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
-        \["markdownFile", ".*\.md", "NONE", "yellow", "NONE", "yellow"],
+        \["RubySpecFile", "file", ".*_spec\.rb", "NONE", "red", "NONE", "red"],
+        \["MarkdownFile", "file", ".*\.md", "NONE", "blue", "NONE", "blue"],
+        \["SpecDir", "dir", "spec", "NONE", "yellow", "NONE", "yellow"],
         \]
 
 -------------------------------------------------------------------------------
@@ -122,8 +134,14 @@ highlight BufferNavigatorDir                               *BufferNavigatorDir*
 ===============================================================================
 Changelog                                          *buffer-navigator-changelog*
 
-- 1.1.0 Add option to define highlight rules
-- 1.0.0 Initial release
+- 2.0.0
+  - Add MRU mode
+  - BREAKING CHANGE: user-defined highlight rules got a new second parameter:
+    kind ("file" | "dir")
+- 1.1.0
+  - Add option to define highlight rules
+- 1.0.0
+  - Initial release
 
 ===============================================================================
 License                                              *buffer-navigator-license*

--- a/doc/buffer-navigator.txt
+++ b/doc/buffer-navigator.txt
@@ -1,4 +1,4 @@
-*buffer-navigator.txt*                                            Version 1.0.0
+*buffer-navigator.txt*                                            Version 2.0.0
 
   ____         __  __                                 ~
  |  _ \       / _|/ _|                                ~

--- a/ftplugin/buffernavigator.vim
+++ b/ftplugin/buffernavigator.vim
@@ -1,0 +1,4 @@
+setlocal buftype=nofile bufhidden=wipe nowrap noswapfile
+setlocal nobuflisted nonumber nofoldenable
+setlocal conceallevel=2 concealcursor=nvic
+

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -1,9 +1,10 @@
-let s:bufferLineMapping = {}
 let s:optionWindowWidth = ['BufferNavigatorWidth', 40]
 let s:optionHighlightRules = ['BufferNavigatorHighlightRules', []]
 let s:optionMode = ['BufferNavigatorMode', 'tree']
-let s:currentMode = get(g:,s:optionMode[0], s:optionMode[1])
 let s:optionMapKeys = ['BufferNavigatorMapKeys', 1]
+
+let s:bufferLineMapping = {}
+let s:currentMode = get(g:,s:optionMode[0], s:optionMode[1])
 let s:buffername = "buffer-navigator"
 let s:fileMarker = "\x07"
 let s:modifiedMarker = "\x06"

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -1,7 +1,8 @@
-let s:currentMode = "mru"
 let s:bufferLineMapping = {}
 let s:optionWindowWidth = ['BufferNavigatorWidth', 40]
 let s:optionHighlightRules = ['BufferNavigatorHighlightRules', []]
+let s:optionMode = ['BufferNavigatorMode', 'tree']
+let s:currentMode = get(g:,s:optionMode[0], s:optionMode[1])
 let s:optionMapKeys = ['BufferNavigatorMapKeys', 1]
 let s:buffername = "buffer-navigator"
 let s:fileMarker = "\x07"
@@ -165,8 +166,15 @@ function! s:Open()
   nnoremap <script> <silent> <nowait> <buffer> s    :call <SID>SelectBuffer("s", 0)<CR>
   nnoremap <script> <silent> <nowait> <buffer> p    :call <SID>SelectBuffer("", 1)<CR>
   nnoremap <script> <silent> <nowait> <buffer> r    :call <SID>Refresh(1)<CR>
+  nnoremap <script> <silent> <nowait> <buffer> m    :call <SID>ToggleMode()<CR>
   nnoremap <script> <silent> <nowait> <buffer> x    :call <SID>CloseBuffers()<CR>
   nnoremap <script> <silent> <nowait> <buffer> z    :call <SID>ToggleZoom()<CR>
+endfunction
+
+function! s:ToggleMode()
+  let s:currentMode = s:currentMode == "tree" ? "mru" : "tree"
+  call setpos(".", [0, 1, 1])
+  call s:Refresh(1)
 endfunction
 
 function! s:ToggleZoom()

--- a/plugin/buffer-navigator.vim
+++ b/plugin/buffer-navigator.vim
@@ -1,3 +1,4 @@
+let s:currentMode = "mru"
 let s:bufferLineMapping = {}
 let s:optionWindowWidth = ['BufferNavigatorWidth', 40]
 let s:optionHighlightRules = ['BufferNavigatorHighlightRules', []]
@@ -69,9 +70,9 @@ function! s:TreeToLines(tree, startLineNr, level)
   return [lines, lineNr]
 endfunction
 
-function! s:BuildBufferList()
+function! s:BuildBufferList(sortByLastOpened)
   redir => buffers
-  execute('silent ls')
+  execute('silent ls' . (a:sortByLastOpened ? ' t' : ''))
   redir END
 
   let bufferlist = []
@@ -109,9 +110,35 @@ function! s:Focus()
   endif
 endfunction
 
+function! s:PrintMRU()
+  let s:bufferLineMapping = {}
+  let bufferlist = s:BuildBufferList(1)
+  let currentBufferNumber = bufnr("#")
+  let lines = []
+  let lineNr = 1
+
+  for buffer in bufferlist
+    if buffer.nr == currentBufferNumber 
+      continue
+    endif
+
+    let pathSegments = split(buffer.name, "/")
+
+    if len(pathSegments) == 1
+      call add(lines, s:fileMarker . (buffer.modified ? s:modifiedMarker : "") . pathSegments[0])
+    else
+      call add(lines, pathSegments[-2] . "/" . s:fileMarker . (buffer.modified ? s:modifiedMarker : "") . pathSegments[-1])
+    endif
+
+    let s:bufferLineMapping[lineNr] = buffer.nr
+    let lineNr += 1
+  endfor
+  call setline(1, lines)
+endfunction
+
 function! s:PrintLines()
   let s:bufferLineMapping = {}
-  let bufferlist = s:BuildBufferList()
+  let bufferlist = s:BuildBufferList(0)
   let [bufferLines, _] = s:TreeToLines(s:BuffersToTree(bufferlist), 1, 0)
   call setline(1, bufferLines)
 endfunction
@@ -127,10 +154,7 @@ function! s:Open()
   execute 'file ' . s:buffername
   execute "vertical resize " . get(g:,s:optionWindowWidth[0], s:optionWindowWidth[1])
 
-  setlocal buftype=nofile bufhidden=wipe nowrap noswapfile
-  setlocal nobuflisted nonumber nofoldenable
   setlocal filetype=buffernavigator
-  setlocal conceallevel=2 concealcursor=nvic
 
   call s:Refresh(1)
 
@@ -191,10 +215,14 @@ function! s:Refresh(selectCurrentBuffer)
   let previousLineNr = line(".")
   setlocal noreadonly modifiable
   call deletebufline("%", 1, "$")
-  call s:PrintLines()
+  if s:currentMode == "tree"
+    call s:PrintLines()
+  else 
+    call s:PrintMRU()
+  endif
   setlocal readonly nomodifiable
 
-  if !a:selectCurrentBuffer
+  if !a:selectCurrentBuffer || s:currentMode == "mru"
     call setpos(".", [0, previousLineNr, 1])
   else
     let currentBufferNumber = bufnr("#")
@@ -264,10 +292,3 @@ command! BufferNavigatorToggle :call <SID>Toggle()
 if get(g:, s:optionMapKeys[0], s:optionMapKeys[1])
   nnoremap <silent> <leader>b :BufferNavigatorToggle<cr>
 endif
-
-for rule in get(g:,s:optionHighlightRules[0], s:optionHighlightRules[1])
-  let [name, regexp, ctermbg, ctermfg, guibg, guifg] = rule
-  exec 'autocmd filetype buffernavigator syntax match ' . name . ' "\v^\s*' . regexp . '$"'
-  exec 'autocmd filetype buffernavigator highlight ' . name . ' ctermbg='. ctermbg . ' ctermfg=' . ctermfg . ' guibg=' . guibg . ' guifg=' . guifg
-endfor
-

--- a/syntax/buffernavigator.vim
+++ b/syntax/buffernavigator.vim
@@ -20,4 +20,4 @@ endfor
 
 highlight BufferNavigatorFile ctermbg=NONE ctermfg=75 guibg=NONE guifg=Blue
 highlight BufferNavigatorModifiedFile ctermbg=NONE ctermfg=214 guibg=NONE guifg=Orange
-highlight BufferNavigatorDir ctermbg=NONE ctermfg=white guibg=NONE guifg=White
+highlight BufferNavigatorDir ctermbg=NONE ctermfg=White guibg=NONE guifg=White

--- a/syntax/buffernavigator.vim
+++ b/syntax/buffernavigator.vim
@@ -1,19 +1,23 @@
-let s:fileMarker = "\x07"
-let s:modifiedMarker = "\x06"
+let s:fileMarker = "07"
+let s:modifiedMarker = "06"
+let s:optionHighlightRules = ['BufferNavigatorHighlightRules', []]
 
-" hide the file marker
-exec 'syntax match BufferNavigatorFileMarker #\%d' . char2nr(s:fileMarker) . '# conceal containedin=ALL'
-exec 'syntax match BufferNavigatorModifiedMarker #\%d' . char2nr(s:modifiedMarker) . '# conceal containedin=ALL'
+exec 'syntax match BufferNavigatorFileMarker #\m\%d' . s:fileMarker . '# conceal containedin=ALL'
+exec 'syntax match BufferNavigatorModifiedMarker #\m\%d' . s:modifiedMarker . '# conceal containedin=ALL'
+exec 'syntax match BufferNavigatorDir #\m^.*$# contains=BufferNavigatorFile'
+exec 'syntax match BufferNavigatorFile #\m\%d' . s:fileMarker . '.*#'
+exec 'syntax match BufferNavigatorModifiedFile #\m\%d' . s:fileMarker . '\%d' . s:modifiedMarker . '.*# containedin=ALL'
 
-" all lines are directories
-exec 'syntax match BufferNavigatorDir "\v^.*$"'
-
-" ...except the ones with the marker in it
-exec 'syntax match BufferNavigatorFile #^\s*\%d' . char2nr(s:fileMarker) . '.*$#'
-
-" highlight modified files
-exec 'syntax match BufferNavigatorModifiedFile #^\s*\%d' . char2nr(s:fileMarker) . '\%d' . char2nr(s:modifiedMarker) . '.*$# containedin=ALL'
+for rule in get(g:,s:optionHighlightRules[0], s:optionHighlightRules[1])
+  let [name, kind, regexp, ctermbg, ctermfg, guibg, guifg] = rule
+  if kind == "file"
+    exec 'syntax match ' . name . ' #\m\%d' . s:fileMarker . '' . regexp . '# containedin=BufferNavigatorFile'
+  elseif kind == "dir"
+    exec 'syntax match ' . name . ' #\m' . regexp . '#'
+  endif
+  exec 'highlight ' . name . ' ctermbg='. ctermbg . ' ctermfg=' . ctermfg . ' guibg=' . guibg . ' guifg=' . guifg
+endfor
 
 highlight BufferNavigatorFile ctermbg=NONE ctermfg=75 guibg=NONE guifg=Blue
 highlight BufferNavigatorModifiedFile ctermbg=NONE ctermfg=214 guibg=NONE guifg=Orange
-highlight BufferNavigatorDir ctermbg=NONE ctermfg=White guibg=NONE guifg=White
+highlight BufferNavigatorDir ctermbg=NONE ctermfg=white guibg=NONE guifg=White


### PR DESCRIPTION
- Move filetype-specific stuff into `ftplugin/`
- Adjust syntax rules to work with MRU mode
- BREAKING CHANGE for user-defined rules, a new second entry in the tuple has been added: `kind` (See docs)

### ToDo

- [x] Mapping to switch MRU mode on or off
- [x] Increase version
  - Git tag
  - doc/buffer-navigator.txt
- [x] Update docs
- [x] Update changelog
  - CHANGELOG.md
  - doc/buffer-navigator.txt 